### PR TITLE
Firefox justify fix

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -15,46 +15,48 @@
 </head>
 <body>
 	<div id="toolbar"></div>
-	<div id="content-editor" class="clear">
-		<p><strong>jQuery.contentEditable</strong> is a light-weight WYSIWYG rich text editor plugin that uses <em>contentEditable</em> support in modern browsers for in-place HTML editing.</p>
-        <p>Initially developed for <a href="http://draftessay.com/"><em>DraftEssay.com</em></a> (which incidentally, this was written in), I have decided to open-source it to encourage development.</p>
-        <h2>Example</h2>
-        <p>Click on this text and type something. Press "Save Changes" to get the changed HTML of the editable areas.</p>
-        <h2>Dependencies</h2>
-        <p>jQuery ContentEditable depends on jQuery and <em>shortcut.js</em> for keyboard shortcuts, as given below.</p>
-        <h2>Download</h2>
-        <p>The source is hosted on <a href="https://bitbucket.org/freshcode/jquery.contenteditable">BitBucket</a>, which you can clone like so:</p>
-        <p><em>$ hg clone <a href="https://bitbucket.org/freshcode/jquery.contenteditable">https://bitbucket.org/freshcode/jquery.contenteditable</a></em></p>
-        <h3>Usage</h3>
-        <ol>
-                <li>Include jQuery 1.4 or higher.</li>
-                <li>Include <em>shortcut.js</em> (included with package).</li>
-                <li>Include <em>jquery.contenteditable.js</em></li>
-                <li>Link to <em>jquery.contenteditable.css</em> for toolbar styles</li>
-        </ol>
-        <h3>Some jQuery Calls:</h3>
-        <ol>
-                <li>To initialise the toolbar, call <em>$(".fresheditable").fresheditor();</em><br />
-                </li>
-                <li>To start/stop editing, call <em>$(".fresheditable").fresheditor("edit", true);</em> for editable elements.</li>
-                <li>To save, call <em>$(".fresheditable").fresheditor("save", function(id, content) { ... });</em> to have the callback function called for each editable element being saved.</li>
-        </ol>
-        <h2>Keyboard Shortcuts</h2>
-        <ul>
-                <li><strong>Tab</strong> indents the selected content</li>
-                <li><strong>Shift+Tab</strong> outdents selected content</li>
-                <li><strong>Ctrl+B</strong> makes text <strong>bold</strong><br />
-                </li>
-                <li><strong>Ctrl+I</strong> makes text <em>italic</em></li>
-                <li><strong>Ctrl+U</strong> <u>underlines</u> text</li>
-                <li><strong>Ctrl+L</strong> inserts a <a href="#">link</a><br />
-                </li>
-                <li><strong>Ctrl+Alt+0</strong> formats a paragraph</li>
-                <li><strong>Ctrl+Alt+1</strong> through <strong>Ctrl+Alt+5</strong> adds headings 1 through 5</li>
-                <li><strong>Ctrl+J</strong> creates an unordered list, like this one<br />
-                </li>
-                <li><strong>Ctrl+K</strong> creates an ordered list.</li>
-        </ul>
+	<div id="wrapper">
+	  <div id="content-editor" class="clear">
+  		<p><strong>jQuery.contentEditable</strong> is a light-weight WYSIWYG rich text editor plugin that uses <em>contentEditable</em> support in modern browsers for in-place HTML editing.</p>
+          <p>Initially developed for <a href="http://draftessay.com/"><em>DraftEssay.com</em></a> (which incidentally, this was written in), I have decided to open-source it to encourage development.</p>
+          <h2>Example</h2>
+          <p>Click on this text and type something. Press "Save Changes" to get the changed HTML of the editable areas.</p>
+          <h2>Dependencies</h2>
+          <p>jQuery ContentEditable depends on jQuery and <em>shortcut.js</em> for keyboard shortcuts, as given below.</p>
+          <h2>Download</h2>
+          <p>The source is hosted on <a href="https://bitbucket.org/freshcode/jquery.contenteditable">BitBucket</a>, which you can clone like so:</p>
+          <p><em>$ hg clone <a href="https://bitbucket.org/freshcode/jquery.contenteditable">https://bitbucket.org/freshcode/jquery.contenteditable</a></em></p>
+          <h3>Usage</h3>
+          <ol>
+                  <li>Include jQuery 1.4 or higher.</li>
+                  <li>Include <em>shortcut.js</em> (included with package).</li>
+                  <li>Include <em>jquery.contenteditable.js</em></li>
+                  <li>Link to <em>jquery.contenteditable.css</em> for toolbar styles</li>
+          </ol>
+          <h3>Some jQuery Calls:</h3>
+          <ol>
+                  <li>To initialise the toolbar, call <em>$(".fresheditable").fresheditor();</em><br />
+                  </li>
+                  <li>To start/stop editing, call <em>$(".fresheditable").fresheditor("edit", true);</em> for editable elements.</li>
+                  <li>To save, call <em>$(".fresheditable").fresheditor("save", function(id, content) { ... });</em> to have the callback function called for each editable element being saved.</li>
+          </ol>
+          <h2>Keyboard Shortcuts</h2>
+          <ul>
+                  <li><strong>Tab</strong> indents the selected content</li>
+                  <li><strong>Shift+Tab</strong> outdents selected content</li>
+                  <li><strong>Ctrl+B</strong> makes text <strong>bold</strong><br />
+                  </li>
+                  <li><strong>Ctrl+I</strong> makes text <em>italic</em></li>
+                  <li><strong>Ctrl+U</strong> <u>underlines</u> text</li>
+                  <li><strong>Ctrl+L</strong> inserts a <a href="#">link</a><br />
+                  </li>
+                  <li><strong>Ctrl+Alt+0</strong> formats a paragraph</li>
+                  <li><strong>Ctrl+Alt+1</strong> through <strong>Ctrl+Alt+5</strong> adds headings 1 through 5</li>
+                  <li><strong>Ctrl+J</strong> creates an unordered list, like this one<br />
+                  </li>
+                  <li><strong>Ctrl+K</strong> creates an ordered list.</li>
+          </ul>
+  	</div>
 	</div>
 </body>
 </html>

--- a/freshereditor.js
+++ b/freshereditor.js
@@ -53,8 +53,8 @@ Todo:
 			$('#fontname-select').toggle();
 		},
 		FontSize: function() {
-			var pos = $('.toolbar_FontSize').offset();
-			var height = $('.toolbar_FontSize').width();
+			var pos = $('.toolbar_fontSize').offset();
+			var height = $('.toolbar_fontSize').width();
 			$('#fontsize-select').css({"left": pos.left + 'px', "top": pos.top + height + 'px'});
 			$('#fontsize-select').toggle();
 		},

--- a/freshereditor.js
+++ b/freshereditor.js
@@ -53,8 +53,8 @@ Todo:
 			$('#fontname-select').toggle();
 		},
 		FontSize: function() {
-			var pos = $('.toolbar_fontSize').offset();
-			var height = $('.toolbar_fontSize').width();
+			var pos = $('.toolbar_fontsize').offset();
+			var height = $('.toolbar_fontsize').width();
 			$('#fontsize-select').css({"left": pos.left + 'px', "top": pos.top + height + 'px'});
 			$('#fontsize-select').toggle();
 		},


### PR DESCRIPTION
Hi there,

I've recently discovered a bug with freshereditor and Firefox (I'm currently using 4.0.1 but I've reproduced this on 3 as well). If the contentEditable div is wrapped within a 'wrapper' div, the execCommand with any 'justify' command throws an exception. This is a documented bug with Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=442186). I've applied the work-around listed in the discussions on that bug page to the js code.

Regards,

Bart
